### PR TITLE
Add JSON-based basic strategy parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,31 @@
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a/README.md b/README.md
-index 35192f5f18507d70aaab5595458b4f1db72675c8..707742f4f8b89e5618b5125c8963fab8d96c87bd 100644
---- a/README.md
-+++ b/README.md
-@@ -1 +1,27 @@
--# casinosim1
-+# Blackjack Simulator
-+
-+This project provides a configurable blackjack simulator for collecting statistics on player survival and card distributions.
-+
-+## Features
-+- Modular number of decks.
-+- Dealer hits or stands on soft 17.
-+- Penetration-based shoe with automatic shuffle.
-+- Optional double after split and re-split aces.
-+- Surrender allowed before any action.
-+- Results stored in SQLite for post-processing.
-+- R script to generate line graphs of bankroll and card distributions.
-+
-+## Usage
-+Run simulations via the CLI:
-+
-+```bash
-+python -m blackjack.main --trials 10 --hands 50 --bankroll 500 --payout 1.5 --decks 6 --penetration 0.75 --strategy strategy.json --database simulation.db
-+```
-+
-+After running, create graphs with R:
-+
-+```bash
-+Rscript analysis.R simulation.db
-+```
-+
-+The simulator expects a JSON basic strategy file. The provided `strategy.json` is a placeholder that stands on all hands.
- 
-EOF
-)
+# Blackjack Simulator
+
+This project provides a configurable blackjack simulator for collecting statistics on player survival and card distributions.
+
+## Features
+- Modular number of decks.
+- Dealer hits or stands on soft 17.
+- Penetration-based shoe with automatic shuffle.
+- Optional double after split and re-split aces.
+- Surrender allowed before any action.
+- Results stored in SQLite for post-processing.
+- R script to generate line graphs of bankroll and card distributions.
+
+## Usage
+Run simulations via the CLI:
+
+```bash
+python -m blackjack.main --trials 10 --hands 50 --bankroll 500 --payout 1.5 --decks 6 --penetration 0.75 --strategy strategy.json --database simulation.db
+```
+
+After running, create graphs with R:
+
+```bash
+Rscript analysis.R simulation.db
+```
+
+The simulator expects a JSON basic strategy file.  The file contains three
+objects – `hard`, `soft` and `pair` – each mapping the player's total (or pair
+rank) and the dealer's up card to an action (`hit`, `stand`, `double`, `split`
+or `surrender`).  The provided `strategy.json` is a minimal placeholder that
+stands on all hands.

--- a/strategy.json
+++ b/strategy.json
@@ -1,10 +1,5 @@
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a//dev/null b/strategy.json
-index 0000000000000000000000000000000000000000..0967ef424bce6791893e9a57bb952f80fd536e93 100644
---- a//dev/null
-+++ b/strategy.json
-@@ -0,0 +1 @@
-+{}
- 
-EOF
-)
+{
+  "hard": {},
+  "soft": {},
+  "pair": {}
+}

--- a/strategy.py
+++ b/strategy.py
@@ -1,123 +1,69 @@
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a//dev/null b/blackjack/strategy.py
-index 0000000000000000000000000000000000000000..10150d40754b2bf791949a6209889ed5dff24867 100644
---- a//dev/null
-+++ b/blackjack/strategy.py
-@@ -0,0 +1,114 @@
-+from __future__ import annotations
-+from dataclasses import dataclass
-+from typing import Dict
-+from .hand import Hand
-+
-+Action = str  # 'hit', 'stand', 'double', 'split', 'surrender'
-+
-+
-+@dataclass
-+class BasicStrategy:
-+    """Implements a basic strategy matrix for blackjack.
-+
-+    The rules are derived from the matrix provided in the project notes.  The
-+    decision engine works off the current hand state so that subsequent hits
-+    consider the new totals rather than only the first two cards.
-+    """
-+
-+    @classmethod
-+    def from_json(cls, path: str) -> "BasicStrategy":  # pragma: no cover - kept for CLI compatibility
-+        return cls()
-+
-+    def decide(self, hand: Hand, dealer_up: str, options: Dict[str, bool]) -> Action:
-+        """Return the recommended action for *hand* against *dealer_up*.
-+
-+        Parameters in *options* indicate if doubling, splitting or surrendering
-+        are legal in the current context.
-+        """
-+        # Splits
-+        if options.get("can_split") and hand.can_split:
-+            r = hand.cards[0].rank
-+            if r in {"A", "8"}:
-+                return "split"
-+            split_rules = {
-+                "2": {"2", "3", "4", "5", "6"},
-+                "3": {"3", "4", "5", "6"},
-+                "4": {"5", "6"},
-+                "6": {"2", "3", "4", "5", "6"},
-+                "7": {"2", "3", "4", "5", "6", "7"},
-+                "9": {"2", "3", "4", "5", "6", "8", "9"},
-+            }
-+            if r in split_rules and dealer_up in split_rules[r]:
-+                return "split"
-+
-+        total = hand.best_value
-+        soft = any(v <= 21 and v != total for v in hand.values)
-+
-+        # Surrender
-+        if options.get("can_surrender") and not soft and len(hand.cards) == 2:
-+            if total == 15 and dealer_up == "10":
-+                return "surrender"
-+            if total == 16 and dealer_up in {"9", "10", "A"}:
-+                return "surrender"
-+
-+        # Doubles (two-card hands only)
-+        if options.get("can_double") and len(hand.cards) == 2:
-+            if not soft:
-+                if total == 9 and dealer_up in {"3", "4", "5", "6"}:
-+                    return "double"
-+                if total == 10 and dealer_up in {"2", "3", "4", "5", "6", "7", "8", "9"}:
-+                    return "double"
-+                if total == 11:
-+                    return "double"
-+            else:
-+                if total == 13 and dealer_up in {"5", "6"}:
-+                    return "double"
-+                if total == 14 and dealer_up in {"5", "6"}:
-+                    return "double"
-+                if total == 15 and dealer_up in {"4", "5", "6"}:
-+                    return "double"
-+                if total == 16 and dealer_up in {"4", "5", "6"}:
-+                    return "double"
-+                if total == 17 and dealer_up in {"3", "4", "5", "6"}:
-+                    return "double"
-+                if total == 18 and dealer_up in {"2", "3", "4", "5", "6"}:
-+                    return "double"
-+                if total == 19 and dealer_up == "6":
-+                    return "double"
-+
-+        # Stand / Hit logic
-+        if not soft:
-+            if total >= 17:
-+                return "stand"
-+            if total == 16 and dealer_up in {"2", "3", "4", "5", "6"}:
-+                return "stand"
-+            if total == 15 and dealer_up in {"2", "3", "4", "5", "6"}:
-+                return "stand"
-+            if total == 14 and dealer_up in {"2", "3", "4", "5", "6"}:
-+                return "stand"
-+            if total == 13 and dealer_up in {"2", "3", "4", "5", "6"}:
-+                return "stand"
-+            if total == 12 and dealer_up in {"4", "5", "6"}:
-+                return "stand"
-+            return "hit"
-+        else:
-+            if total >= 20:
-+                return "stand"
-+            if total == 19:
-+                if dealer_up == "6" and options.get("can_double") and len(hand.cards) == 2:
-+                    return "double"
-+                return "stand"
-+            if total == 18:
-+                if dealer_up in {"7", "8"}:
-+                    return "stand"
-+                if dealer_up in {"2", "3", "4", "5", "6"}:
-+                    return "stand"
-+                return "hit"
-+            if total == 17:
-+                return "hit"
-+            if total in {13, 14}:
-+                return "hit"
-+            if total in {15, 16}:
-+                return "hit"
-+            return "hit"
-+
- 
-EOF
-)
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Dict
+import json
+from .hand import Hand
+
+Action = str  # 'hit', 'stand', 'double', 'split', 'surrender'
+
+
+@dataclass
+class BasicStrategy:
+    """Strategy based on a matrix loaded from JSON.
+
+    The JSON file is expected to contain three top level objects: ``hard``,
+    ``soft`` and ``pair``.  Each maps a player's total (or pair rank) to a
+    mapping of dealer up cards (``"2"``..``"10"``, ``"A"``) and the
+    recommended action (``hit``, ``stand``, ``double``, ``split`` or
+    ``surrender``).
+    """
+
+    hard: Dict[int, Dict[str, Action]] = field(default_factory=dict)
+    soft: Dict[int, Dict[str, Action]] = field(default_factory=dict)
+    pair: Dict[str, Dict[str, Action]] = field(default_factory=dict)
+
+    @classmethod
+    def from_json(cls, path: str) -> "BasicStrategy":  # pragma: no cover - CLI helper
+        """Create a strategy instance from ``path``.
+
+        Missing sections in the JSON default to empty dictionaries which
+        effectively cause the strategy to stand on every hand.
+        """
+        with open(path, "r", encoding="utf8") as f:
+            data = json.load(f)
+        hard = {int(k): v for k, v in data.get("hard", {}).items()}
+        soft = {int(k): v for k, v in data.get("soft", {}).items()}
+        pair = data.get("pair") or data.get("split") or {}
+        return cls(hard=hard, soft=soft, pair=pair)
+
+    def _lookup(self, table: Dict, key, dealer_up: str) -> Action | None:
+        row = table.get(key)
+        if row:
+            return row.get(dealer_up)
+        return None
+
+    def decide(self, hand: Hand, dealer_up: str, options: Dict[str, bool]) -> Action:
+        """Return the recommended action for *hand* against *dealer_up*.
+
+        ``options`` controls availability of ``double``, ``split`` and
+        ``surrender``.
+        """
+        # Check for pair/split actions first
+        if options.get("can_split") and hand.can_split:
+            rank = hand.cards[0].rank
+            action = self._lookup(self.pair, rank, dealer_up)
+            if action == "split":
+                return "split"
+
+        total = hand.best_value
+        soft = any(v <= 21 and v != total for v in hand.values)
+        table = self.soft if soft else self.hard
+        action = self._lookup(table, total, dealer_up)
+
+        # Fallback when action requires an unavailable option
+        if action == "double" and not options.get("can_double"):
+            action = "hit"
+        if action == "surrender" and not options.get("can_surrender"):
+            action = "hit"
+
+        return action or "stand"


### PR DESCRIPTION
## Summary
- Replace hard-coded strategy logic with JSON-driven `BasicStrategy`
- Provide placeholder `strategy.json` format and update docs

## Testing
- `python -m py_compile strategy.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4a55235648331bcaa8c5ab56d7d0b