### PR TITLE
Prevent extra hits when resplitting aces disabled

### DIFF
--- a/blackjack/cards.py
+++ b/blackjack/cards.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import List
+import random
+
+SUITS = ["hearts", "diamonds", "clubs", "spades"]
+RANKS = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"]
+
+@dataclass(frozen=True)
+class Card:
+    rank: str
+    suit: str
+
+    @property
+    def value(self) -> int:
+        if self.rank in ["J", "Q", "K"]:
+            return 10
+        if self.rank == "A":
+            return 11
+        return int(self.rank)
+
+@dataclass
+class Shoe:
+    num_decks: int
+    penetration: float = 0.75
+    _cards: List[Card] = field(default_factory=list, init=False)
+    _discard: List[Card] = field(default_factory=list, init=False)
+    drawn_counts: dict = field(default_factory=lambda: {rank:0 for rank in RANKS}, init=False)
+
+    def __post_init__(self) -> None:
+        self.shuffle()
+
+    def shuffle(self) -> None:
+        self._cards = [Card(rank, suit) for rank in RANKS for suit in SUITS] * self.num_decks
+        random.shuffle(self._cards)
+        self._discard.clear()
+
+    def draw(self) -> Card:
+        card = self._cards.pop()
+        self._discard.append(card)
+        self.drawn_counts[card.rank] += 1
+        return card
+
+    @property
+    def penetration_reached(self) -> bool:
+        used = len(self._discard)
+        total = self.num_decks * 52
+        return used / total >= self.penetration

--- a/blackjack/hand.py
+++ b/blackjack/hand.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import List
+from .cards import Card
+
+@dataclass
+class Hand:
+    cards: List[Card] = field(default_factory=list)
+    bet: float = 0.0
+    is_split_aces: bool = False
+    is_split: bool = False
+    surrendered: bool = False
+
+    def add_card(self, card: Card) -> None:
+        self.cards.append(card)
+
+    @property
+    def values(self) -> List[int]:
+        totals = [0]
+        for card in self.cards:
+            if card.rank == "A":
+                totals = [t + 1 for t in totals] + [t + 11 for t in totals]
+            else:
+                totals = [t + card.value for t in totals]
+        return sorted(set(totals))
+
+    @property
+    def best_value(self) -> int:
+        valid = [v for v in self.values if v <= 21]
+        return max(valid) if valid else min(self.values)
+
+    @property
+    def is_blackjack(self) -> bool:
+        return len(self.cards) == 2 and self.best_value == 21
+
+    @property
+    def is_bust(self) -> bool:
+        return min(self.values) > 21
+
+    @property
+    def can_split(self) -> bool:
+        return len(self.cards) == 2 and self.cards[0].rank == self.cards[1].rank

--- a/blackjack/player.py
+++ b/blackjack/player.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import List
+from .hand import Hand
+from .cards import Shoe
+from .strategy import BasicStrategy
+
+@dataclass
+class PlayerSettings:
+    bankroll: float
+    blackjack_payout: float = 1.5
+    double_after_split: bool = True
+    resplit_aces: bool = False
+    bet_amount: float = 1.0  # base wager per hand
+
+@dataclass
+class Player:
+    settings: PlayerSettings
+    strategy: BasicStrategy
+
+    def play(self, shoe: Shoe, dealer_up: str, initial: Hand) -> List[Hand]:
+        hands = [initial]
+        i = 0
+        while i < len(hands):
+            hand = hands[i]
+            self._play_hand(hand, shoe, dealer_up, hands)
+            i += 1
+        return hands
+
+    def _play_hand(self, hand: Hand, shoe: Shoe, dealer_up: str, hands: List[Hand]) -> None:
+        # Surrender decision
+        can_double = not hand.is_split or self.settings.double_after_split
+        action = self.strategy.decide(hand, dealer_up, {
+            "can_double": can_double and not hand.is_split_aces,
+            "can_split": hand.can_split,
+            "can_surrender": not hand.is_split,
+        })
+        if action == "surrender":
+            hand.surrendered = True
+            hand.bet /= 2
+            return
+        while True:
+            if hand.is_blackjack or hand.is_bust:
+                return
+            if hand.is_split_aces and len(hand.cards) == 2 and (
+                not self.settings.resplit_aces or hand.cards[1].rank != "A"
+            ):
+                return
+            can_double = (
+                len(hand.cards) == 2
+                and (not hand.is_split or self.settings.double_after_split)
+                and not hand.is_split_aces
+            )
+            action = self.strategy.decide(hand, dealer_up, {
+                "can_double": can_double,
+                "can_split": hand.can_split,
+                "can_surrender": False,
+            })
+            if action == "stand":
+                return
+            if action == "double" and len(hand.cards) == 2 and self.settings.bankroll >= hand.bet:
+                self.settings.bankroll -= hand.bet
+                hand.bet *= 2
+                hand.add_card(shoe.draw())
+                return
+            if action == "split" and hand.can_split and self.settings.bankroll >= hand.bet:
+                rank = hand.cards[0].rank
+                if rank == "A":
+                    ace_hands = sum(1 for h in hands if h.is_split_aces)
+                    if hand.is_split_aces and (not self.settings.resplit_aces or ace_hands >= 4):
+                        action = "hit"
+                    else:
+                        self.settings.bankroll -= hand.bet
+                        new_hand = Hand(cards=[hand.cards.pop()], bet=hand.bet, is_split_aces=True, is_split=True)
+                        hand.is_split_aces = True
+                        hand.is_split = True
+                        hand.add_card(shoe.draw())
+                        new_hand.add_card(shoe.draw())
+                        hands.append(new_hand)
+                        continue
+                else:
+                    self.settings.bankroll -= hand.bet
+                    new_hand = Hand(cards=[hand.cards.pop()], bet=hand.bet, is_split_aces=False, is_split=True)
+                    hand.is_split = True
+                    hand.add_card(shoe.draw())
+                    new_hand.add_card(shoe.draw())
+                    hands.append(new_hand)
+                    continue
+            hand.add_card(shoe.draw())

--- a/blackjack/strategy.py
+++ b/blackjack/strategy.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Dict
+import json
+from .hand import Hand
+
+Action = str  # 'hit', 'stand', 'double', 'split', 'surrender'
+
+
+@dataclass
+class BasicStrategy:
+    """Strategy based on a matrix loaded from JSON.
+
+    The JSON file is expected to contain three top level objects: ``hard``,
+    ``soft`` and ``pair``.  Each maps a player's total (or pair rank) to a
+    mapping of dealer up cards (``"2"``..``"10"``, ``"A"``) and the
+    recommended action (``hit``, ``stand``, ``double``, ``split`` or
+    ``surrender``).
+    """
+
+    hard: Dict[int, Dict[str, Action]] = field(default_factory=dict)
+    soft: Dict[int, Dict[str, Action]] = field(default_factory=dict)
+    pair: Dict[str, Dict[str, Action]] = field(default_factory=dict)
+
+    @classmethod
+    def from_json(cls, path: str) -> "BasicStrategy":  # pragma: no cover - CLI helper
+        """Create a strategy instance from ``path``.
+
+        Missing sections in the JSON default to empty dictionaries which
+        effectively cause the strategy to stand on every hand.
+        """
+        with open(path, "r", encoding="utf8") as f:
+            data = json.load(f)
+        hard = {int(k): v for k, v in data.get("hard", {}).items()}
+        soft = {int(k): v for k, v in data.get("soft", {}).items()}
+        pair = data.get("pair") or data.get("split") or {}
+        return cls(hard=hard, soft=soft, pair=pair)
+
+    def _lookup(self, table: Dict, key, dealer_up: str) -> Action | None:
+        row = table.get(key)
+        if row:
+            return row.get(dealer_up)
+        return None
+
+    def decide(self, hand: Hand, dealer_up: str, options: Dict[str, bool]) -> Action:
+        """Return the recommended action for *hand* against *dealer_up*.
+
+        ``options`` controls availability of ``double``, ``split`` and
+        ``surrender``.
+        """
+        # Check for pair/split actions first
+        if options.get("can_split") and hand.can_split:
+            rank = hand.cards[0].rank
+            action = self._lookup(self.pair, rank, dealer_up)
+            if action == "split":
+                return "split"
+
+        total = hand.best_value
+        soft = any(v <= 21 and v != total for v in hand.values)
+        table = self.soft if soft else self.hard
+        action = self._lookup(table, total, dealer_up)
+
+        # Fallback when action requires an unavailable option
+        if action == "double" and not options.get("can_double"):
+            action = "hit"
+        if action == "surrender" and not options.get("can_surrender"):
+            action = "hit"
+
+        return action or "stand"

--- a/tests/test_split_aces.py
+++ b/tests/test_split_aces.py
@@ -1,0 +1,39 @@
+import pytest
+from blackjack.player import Player, PlayerSettings
+from blackjack.hand import Hand
+from blackjack.cards import Card
+
+class AlwaysSplitStrategy:
+    def decide(self, hand, dealer_up, options):
+        if options.get("can_split") and hand.can_split:
+            return "split"
+        return "stand"
+
+class MockShoe:
+    def __init__(self, cards):
+        self.cards = list(cards)
+        self.drawn = []
+    def draw(self):
+        card = self.cards.pop(0)
+        self.drawn.append(card)
+        return card
+
+
+def test_no_extra_card_when_resplit_disabled():
+    # prepare initial hand of two aces
+    initial = Hand(cards=[Card('A','spades'), Card('A','hearts')], bet=1.0)
+    # shoe will deal Ace then 5, and extra 9 if bug occurs
+    shoe = MockShoe([
+        Card('A','clubs'),
+        Card('5','diamonds'),
+        Card('9','hearts'),
+    ])
+    player = Player(
+        settings=PlayerSettings(bankroll=100, resplit_aces=False),
+        strategy=AlwaysSplitStrategy(),
+    )
+    hands = player.play(shoe, dealer_up='5', initial=initial)
+    # two hands should have only two cards each
+    assert all(len(h.cards) == 2 for h in hands)
+    # only two cards should be drawn from the shoe (for the split)
+    assert len(shoe.drawn) == 2


### PR DESCRIPTION
## Summary
- ensure split aces stop play when resplitting is disabled
- add regression test verifying no extra cards are dealt after a split ace hand has two cards

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4a7b2ed448331b229ae2e3ef164e7