### PR TITLE
Allow seeding simulations for reproducible results

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ python -m blackjack.main \
     --double-after-split \
     --resplit-aces \
     --strategy strategy.json \
-    --database simulation.db
+    --database simulation.db \
+    --seed 42
 
 ```
 

--- a/blackjack/gui.py
+++ b/blackjack/gui.py
@@ -71,6 +71,10 @@ class SimulatorGUI:
         self.penetration = tk.DoubleVar(value=0.75)
         tk.Spinbox(controls, from_=0.1, to=1.0, increment=0.05, textvariable=self.penetration).grid(row=3, column=5)
 
+        tk.Label(controls, text="Seed").grid(row=4, column=0)
+        self.seed = tk.StringVar()
+        ttk.Entry(controls, textvariable=self.seed).grid(row=4, column=1)
+
         tk.Button(controls, text="Run", command=self.run_simulation).grid(row=2, column=4)
         self.save_btn = tk.Button(controls, text="Save", command=self.save_results, state=tk.DISABLED)
         self.save_btn.grid(row=2, column=5)
@@ -93,6 +97,7 @@ class SimulatorGUI:
             penetration=float(self.penetration.get()),
             strategy_file=self.strategy_file.get(),
             database=self.database.get(),
+            seed=int(self.seed.get()) if self.seed.get() else None,
         )
         self.sim = Simulator(settings)
         self.sim.run()

--- a/blackjack/main.py
+++ b/blackjack/main.py
@@ -18,6 +18,7 @@ def parse_args() -> tuple[SimulationSettings, bool]:
     parser.add_argument("--penetration", type=float, default=0.75)
     parser.add_argument("--strategy", type=str, default="strategy.json")
     parser.add_argument("--database", type=str, default="simulation.db")
+    parser.add_argument("--seed", type=int, default=None, help="Random seed")
     parser.add_argument("--no-save", action="store_true", help="Do not save simulation results")
     args = parser.parse_args()
     if not Path(args.strategy).is_file():
@@ -35,6 +36,7 @@ def parse_args() -> tuple[SimulationSettings, bool]:
         penetration=args.penetration,
         strategy_file=args.strategy,
         database=args.database,
+        seed=args.seed,
     )
     return settings, args.no_save
 

--- a/blackjack/settings.py
+++ b/blackjack/settings.py
@@ -14,3 +14,4 @@ class SimulationSettings:
     penetration: float = 0.75
     strategy_file: str = "strategy.json"
     database: str = "simulation.db"
+    seed: int | None = None

--- a/blackjack/simulator.py
+++ b/blackjack/simulator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import sqlite3
+import random
 
 from dataclasses import asdict
 
@@ -46,6 +47,8 @@ class Simulator:
         self.conn.commit()
 
     def run(self) -> None:
+        if self.settings.seed is not None:
+            random.seed(self.settings.seed)
         strat = BasicStrategy.from_json(self.settings.strategy_file)
         for trial in range(1, self.settings.trials + 1):
             shoe = Shoe(self.settings.num_decks, penetration=self.settings.penetration)

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -1,0 +1,38 @@
+from blackjack.simulator import Simulator
+from blackjack.settings import SimulationSettings
+
+
+def test_simulator_seed_reproducible(tmp_path):
+    strategy_file = tmp_path / "strategy.json"
+    strategy_file.write_text("{}")
+    settings = SimulationSettings(
+        trials=1,
+        hands_per_game=5,
+        bankroll=10,
+        blackjack_payout=1.5,
+        double_after_split=True,
+        resplit_aces=False,
+        bet_amount=1.0,
+        num_decks=1,
+        hit_soft_17=False,
+        penetration=0.75,
+        strategy_file=str(strategy_file),
+        database=":memory:",
+        seed=42,
+    )
+    sim1 = Simulator(settings)
+    sim1.run()
+    cur1 = sim1.conn.cursor()
+    cur1.execute("SELECT card, count FROM temp_card_distribution ORDER BY card")
+    dist1 = cur1.fetchall()
+    sim1.close()
+
+    sim2 = Simulator(settings)
+    sim2.run()
+    cur2 = sim2.conn.cursor()
+    cur2.execute("SELECT card, count FROM temp_card_distribution ORDER BY card")
+    dist2 = cur2.fetchall()
+    sim2.close()
+
+    assert dist1 == dist2
+


### PR DESCRIPTION
## Summary
- Support an optional `seed` setting to control the random generator
- Add `--seed` CLI argument and GUI input
- Ensure simulator seeds the RNG when `seed` is provided
- Document and test deterministic simulations with a fixed seed

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b683e8509c8331964fc7ecd30c4e90