### PR TITLE
feat: replace default blackjack strategy file

### DIFF
--- a/BJ_basicStrategy.json
+++ b/BJ_basicStrategy.json
@@ -1,0 +1,337 @@
+{
+  "hard": {
+    "4": {
+      "2": "hit",
+      "3": "hit",
+      "4": "hit",
+      "5": "hit",
+      "6": "hit",
+      "7": "hit",
+      "8": "hit",
+      "9": "hit",
+      "10": "hit",
+      "A": "hit"
+    },
+    "5": {
+      "2": "hit",
+      "3": "hit",
+      "4": "hit",
+      "5": "hit",
+      "6": "hit",
+      "7": "hit",
+      "8": "hit",
+      "9": "hit",
+      "10": "hit",
+      "A": "hit"
+    },
+    "6": {
+      "2": "hit",
+      "3": "hit",
+      "4": "hit",
+      "5": "hit",
+      "6": "hit",
+      "7": "hit",
+      "8": "hit",
+      "9": "hit",
+      "10": "hit",
+      "A": "hit"
+    },
+    "7": {
+      "2": "hit",
+      "3": "hit",
+      "4": "hit",
+      "5": "hit",
+      "6": "hit",
+      "7": "hit",
+      "8": "hit",
+      "9": "hit",
+      "10": "hit",
+      "A": "hit"
+    },
+    "8": {
+      "2": "hit",
+      "3": "hit",
+      "4": "hit",
+      "5": "hit",
+      "6": "hit",
+      "7": "hit",
+      "8": "hit",
+      "9": "hit",
+      "10": "hit",
+      "A": "hit"
+    },
+    "9": {
+      "2": "hit",
+      "3": "double",
+      "4": "double",
+      "5": "double",
+      "6": "double",
+      "7": "hit",
+      "8": "hit",
+      "9": "hit",
+      "10": "hit",
+      "A": "hit"
+    },
+    "10": {
+      "2": "double",
+      "3": "double",
+      "4": "double",
+      "5": "double",
+      "6": "double",
+      "7": "double",
+      "8": "double",
+      "9": "double",
+      "10": "hit",
+      "A": "hit"
+    },
+    "11": {
+      "2": "double",
+      "3": "double",
+      "4": "double",
+      "5": "double",
+      "6": "double",
+      "7": "double",
+      "8": "double",
+      "9": "double",
+      "10": "double",
+      "A": "double"
+    },
+    "12": {
+      "2": "hit",
+      "3": "hit",
+      "4": "stand",
+      "5": "stand",
+      "6": "stand",
+      "7": "hit",
+      "8": "hit",
+      "9": "hit",
+      "10": "hit",
+      "A": "hit"
+    },
+    "13": {
+      "2": "stand",
+      "3": "stand",
+      "4": "stand",
+      "5": "stand",
+      "6": "stand",
+      "7": "hit",
+      "8": "hit",
+      "9": "hit",
+      "10": "hit",
+      "A": "hit"
+    },
+    "14": {
+      "2": "stand",
+      "3": "stand",
+      "4": "stand",
+      "5": "stand",
+      "6": "stand",
+      "7": "hit",
+      "8": "hit",
+      "9": "hit",
+      "10": "hit",
+      "A": "hit"
+    },
+    "15": {
+      "2": "stand",
+      "3": "stand",
+      "4": "stand",
+      "5": "stand",
+      "6": "stand",
+      "7": "hit",
+      "8": "hit",
+      "9": "hit",
+      "10": "surrender",
+      "A": "hit"
+    },
+    "16": {
+      "2": "stand",
+      "3": "stand",
+      "4": "stand",
+      "5": "stand",
+      "6": "stand",
+      "7": "hit",
+      "8": "hit",
+      "9": "surrender",
+      "10": "surrender",
+      "A": "surrender"
+    }
+  },
+  "soft": {
+    "13": {
+      "2": "hit",
+      "3": "hit",
+      "4": "hit",
+      "5": "double",
+      "6": "double",
+      "7": "hit",
+      "8": "hit",
+      "9": "hit",
+      "10": "hit",
+      "A": "hit"
+    },
+    "14": {
+      "2": "hit",
+      "3": "hit",
+      "4": "hit",
+      "5": "double",
+      "6": "double",
+      "7": "hit",
+      "8": "hit",
+      "9": "hit",
+      "10": "hit",
+      "A": "hit"
+    },
+    "15": {
+      "2": "hit",
+      "3": "hit",
+      "4": "double",
+      "5": "double",
+      "6": "double",
+      "7": "hit",
+      "8": "hit",
+      "9": "hit",
+      "10": "hit",
+      "A": "hit"
+    },
+    "16": {
+      "2": "hit",
+      "3": "hit",
+      "4": "double",
+      "5": "double",
+      "6": "double",
+      "7": "hit",
+      "8": "hit",
+      "9": "hit",
+      "10": "hit",
+      "A": "hit"
+    },
+    "17": {
+      "2": "hit",
+      "3": "double",
+      "4": "double",
+      "5": "double",
+      "6": "double",
+      "7": "hit",
+      "8": "hit",
+      "9": "hit",
+      "10": "hit",
+      "A": "hit"
+    },
+    "18": {
+      "2": "double",
+      "3": "double",
+      "4": "double",
+      "5": "double",
+      "6": "double",
+      "7": "stand",
+      "8": "stand",
+      "9": "hit",
+      "10": "hit",
+      "A": "hit"
+    },
+    "19": {
+      "2": "stand",
+      "3": "stand",
+      "4": "stand",
+      "5": "stand",
+      "6": "double",
+      "7": "stand",
+      "8": "stand",
+      "9": "stand",
+      "10": "stand",
+      "A": "stand"
+    },
+    "20": {
+      "2": "stand",
+      "3": "stand",
+      "4": "stand",
+      "5": "stand",
+      "6": "stand",
+      "7": "stand",
+      "8": "stand",
+      "9": "stand",
+      "10": "stand",
+      "A": "stand"
+    },
+    "21": {
+      "2": "stand",
+      "3": "stand",
+      "4": "stand",
+      "5": "stand",
+      "6": "stand",
+      "7": "stand",
+      "8": "stand",
+      "9": "stand",
+      "10": "stand",
+      "A": "stand"
+    }
+  },
+  "pair": {
+    "2": {
+      "2": "split",
+      "3": "split",
+      "4": "split",
+      "5": "split",
+      "6": "split"
+    },
+    "3": {
+      "3": "split",
+      "4": "split",
+      "5": "split",
+      "6": "split"
+    },
+    "4": {
+      "5": "split",
+      "6": "split"
+    },
+    "6": {
+      "2": "split",
+      "3": "split",
+      "4": "split",
+      "5": "split",
+      "6": "split"
+    },
+    "7": {
+      "2": "split",
+      "3": "split",
+      "4": "split",
+      "5": "split",
+      "6": "split",
+      "7": "split"
+    },
+    "8": {
+      "2": "split",
+      "3": "split",
+      "4": "split",
+      "5": "split",
+      "6": "split",
+      "7": "split",
+      "8": "split",
+      "9": "split",
+      "10": "split",
+      "A": "split"
+    },
+    "9": {
+      "2": "split",
+      "3": "split",
+      "4": "split",
+      "5": "split",
+      "6": "split",
+      "8": "split",
+      "9": "split"
+    },
+    "A": {
+      "2": "split",
+      "3": "split",
+      "4": "split",
+      "5": "split",
+      "6": "split",
+      "7": "split",
+      "8": "split",
+      "9": "split",
+      "10": "split",
+      "A": "split"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ python -m blackjack.main \
     --hit-soft-17 \
     --double-after-split \
     --resplit-aces \
-    --strategy strategy.json \
+    --strategy BJ_basicStrategy.json \
     --database simulation.db \
     --seed 42
 
@@ -72,7 +72,7 @@ blackjack-sim  # runs without a console window
 Rscript analysis.R simulation.db
 ```
 
-The simulator expects `strategy.json` to contain three top-level objects: `hard`, `soft`, and `pair`. Each maps player totals (or pair ranks) and dealer up-cards to recommended actions (`hit`, `stand`, `double`, `split`, `surrender`).
+The simulator expects `BJ_basicStrategy.json` to contain three top-level objects: `hard`, `soft`, and `pair`. Each maps player totals (or pair ranks) and dealer up-cards to recommended actions (`hit`, `stand`, `double`, `split`, `surrender`).
 
 ## Testing
 

--- a/blackjack/gui.py
+++ b/blackjack/gui.py
@@ -60,7 +60,7 @@ class SimulatorGUI:
         tk.Checkbutton(controls, text="RSA", variable=self.rsa).grid(row=2, column=3)
 
         tk.Label(controls, text="Strategy").grid(row=3, column=0)
-        self.strategy_file = tk.StringVar(value="strategy.json")
+        self.strategy_file = tk.StringVar(value="BJ_basicStrategy.json")
         ttk.Entry(controls, textvariable=self.strategy_file).grid(row=3, column=1)
 
         tk.Label(controls, text="Database").grid(row=3, column=2)

--- a/blackjack/main.py
+++ b/blackjack/main.py
@@ -1,7 +1,7 @@
 import argparse
 from pathlib import Path
 
-from .settings import SimulationSettings
+from .settings import SimulationSettings, DEFAULT_STRATEGY_FILE
 from .simulator import Simulator
 
 def parse_args() -> tuple[SimulationSettings, bool]:
@@ -16,7 +16,7 @@ def parse_args() -> tuple[SimulationSettings, bool]:
     parser.add_argument("--decks", type=int, default=6)
     parser.add_argument("--h17", action="store_true", help="Dealer hits on soft 17")
     parser.add_argument("--penetration", type=float, default=0.75)
-    parser.add_argument("--strategy", type=str, default="strategy.json")
+    parser.add_argument("--strategy", type=str, default=str(DEFAULT_STRATEGY_FILE))
     parser.add_argument("--database", type=str, default="simulation.db")
     parser.add_argument("--seed", type=int, default=None, help="Random seed")
     parser.add_argument("--no-save", action="store_true", help="Do not save simulation results")

--- a/blackjack/settings.py
+++ b/blackjack/settings.py
@@ -1,4 +1,8 @@
 from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_STRATEGY_FILE = Path(__file__).resolve().parent.parent / "BJ_basicStrategy.json"
+
 
 @dataclass
 class SimulationSettings:
@@ -12,6 +16,6 @@ class SimulationSettings:
     num_decks: int = 6
     hit_soft_17: bool = False
     penetration: float = 0.75
-    strategy_file: str = "strategy.json"
+    strategy_file: str = str(DEFAULT_STRATEGY_FILE)
     database: str = "simulation.db"
     seed: int | None = None


### PR DESCRIPTION
## Summary
- replace `strategy.json` with detailed `BJ_basicStrategy.json` containing hard, soft, pair, double, split, and surrender logic
- default settings, GUI, and docs now reference `BJ_basicStrategy.json`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6998196ac8331986e4efb1b4f1e3a