### PR TITLE
Add configurable settings UI and surrender toggle

### DIFF
--- a/blackjack/gui.py
+++ b/blackjack/gui.py
@@ -11,6 +11,23 @@ class SimulatorGUI:
         self.root = tk.Tk()
         self.root.title("Blackjack Simulator")
         self.sim = None
+
+        # simulation setting variables
+        self.bankroll = tk.DoubleVar(value=1000)
+        self.trials = tk.IntVar(value=1)
+        self.hands = tk.IntVar(value=6)
+        self.bet = tk.DoubleVar(value=10)
+        self.decks = tk.IntVar(value=6)
+        self.payout = tk.StringVar(value="3:2")
+        self.dealer = tk.StringVar(value="H17")
+        self.das = tk.BooleanVar()
+        self.rsa = tk.BooleanVar()
+        self.surrender = tk.BooleanVar(value=True)
+        self.strategy_file = tk.StringVar(value="BJ_basicStrategy.json")
+        self.database = tk.StringVar(value="simulation.db")
+        self.penetration = tk.DoubleVar(value=0.75)
+        self.seed = tk.StringVar()
+
         self._build_widgets()
 
     def _build_widgets(self):
@@ -25,63 +42,13 @@ class SimulatorGUI:
         controls = tk.Frame(self.root)
         controls.pack(side=tk.BOTTOM, fill=tk.X)
 
-        tk.Label(controls, text="Bankroll").grid(row=0, column=0)
-        self.bankroll = tk.IntVar(value=1000)
-        tk.Spinbox(controls, from_=0, to=100000, increment=100, textvariable=self.bankroll).grid(row=0, column=1)
-
-        tk.Label(controls, text="Trials").grid(row=0, column=2)
-        self.trials = tk.IntVar(value=1)
-        tk.Spinbox(controls, from_=1, to=1000, textvariable=self.trials).grid(row=0, column=3)
-
-        tk.Label(controls, text="Hands/Trial").grid(row=0, column=4)
-        self.hands = tk.IntVar(value=6)
-        tk.Spinbox(controls, from_=1, to=6, textvariable=self.hands).grid(row=0, column=5)
-
-        tk.Label(controls, text="Bet").grid(row=1, column=0)
-        self.bet = tk.IntVar(value=10)
-        tk.Spinbox(controls, from_=1, to=1000, textvariable=self.bet).grid(row=1, column=1)
-
-        tk.Label(controls, text="Decks").grid(row=1, column=2)
-        self.decks = tk.IntVar(value=6)
-        tk.Spinbox(controls, from_=1, to=12, textvariable=self.decks).grid(row=1, column=3)
-
-        tk.Label(controls, text="Payout").grid(row=1, column=4)
-        self.payout = tk.StringVar(value="3:2")
-        ttk.Combobox(controls, textvariable=self.payout, values=["3:2", "6:5"], state="readonly").grid(row=1, column=5)
-
-        tk.Label(controls, text="Dealer").grid(row=2, column=0)
-        self.dealer = tk.StringVar(value="H17")
-        ttk.Combobox(controls, textvariable=self.dealer, values=["H17", "S17"], state="readonly").grid(row=2, column=1)
-
-        self.das = tk.BooleanVar()
-        tk.Checkbutton(controls, text="DAS", variable=self.das).grid(row=2, column=2)
-
-        self.rsa = tk.BooleanVar()
-        tk.Checkbutton(controls, text="RSA", variable=self.rsa).grid(row=2, column=3)
-
-        tk.Label(controls, text="Strategy").grid(row=3, column=0)
-        self.strategy_file = tk.StringVar(value="BJ_basicStrategy.json")
-        ttk.Entry(controls, textvariable=self.strategy_file).grid(row=3, column=1)
-
-        tk.Label(controls, text="Database").grid(row=3, column=2)
-        self.database = tk.StringVar(value="simulation.db")
-        ttk.Entry(controls, textvariable=self.database).grid(row=3, column=3)
-
-        tk.Label(controls, text="Penetration").grid(row=3, column=4)
-        self.penetration = tk.DoubleVar(value=0.75)
-        tk.Spinbox(controls, from_=0.1, to=1.0, increment=0.05, textvariable=self.penetration).grid(row=3, column=5)
-
-        tk.Label(controls, text="Seed").grid(row=4, column=0)
-        self.seed = tk.StringVar()
-        ttk.Entry(controls, textvariable=self.seed).grid(row=4, column=1)
-
-        tk.Button(controls, text="Run", command=self.run_simulation).grid(row=2, column=4)
+        tk.Button(controls, text="Run", command=self.run_simulation).pack(side=tk.LEFT)
         self.save_btn = tk.Button(controls, text="Save", command=self.save_results, state=tk.DISABLED)
-        self.save_btn.grid(row=2, column=5)
+        self.save_btn.pack(side=tk.LEFT)
         self.discard_btn = tk.Button(controls, text="Discard", command=self.discard_results, state=tk.DISABLED)
-        self.discard_btn.grid(row=2, column=6)
+        self.discard_btn.pack(side=tk.LEFT)
 
-        tk.Label(controls, text="Plot Trial").grid(row=4, column=0)
+        tk.Label(controls, text="Plot Trial").pack(side=tk.LEFT)
         self.plot_trial = tk.IntVar(value=1)
         self.plot_trial_spin = tk.Spinbox(
             controls,
@@ -89,8 +56,54 @@ class SimulatorGUI:
             to=1,
             textvariable=self.plot_trial,
             command=self.update_graph,
+            width=5,
         )
-        self.plot_trial_spin.grid(row=4, column=1)
+        self.plot_trial_spin.pack(side=tk.LEFT)
+
+        tk.Button(controls, text="Settings", command=self.open_settings).pack(side=tk.RIGHT)
+
+    def open_settings(self):
+        if hasattr(self, "settings_win") and self.settings_win.winfo_exists():
+            self.settings_win.lift()
+            return
+        self.settings_win = tk.Toplevel(self.root)
+        self.settings_win.title("Settings")
+        frame = tk.Frame(self.settings_win)
+        frame.pack(padx=10, pady=10)
+
+        tk.Label(frame, text="Bankroll").grid(row=0, column=0, sticky="e")
+        tk.Entry(frame, textvariable=self.bankroll).grid(row=0, column=1)
+        tk.Label(frame, text="Trials").grid(row=0, column=2, sticky="e")
+        tk.Entry(frame, textvariable=self.trials).grid(row=0, column=3)
+
+        tk.Label(frame, text="Hands/Trial").grid(row=1, column=0, sticky="e")
+        tk.Spinbox(frame, from_=1, to=6, textvariable=self.hands, width=5).grid(row=1, column=1)
+        tk.Label(frame, text="Bet").grid(row=1, column=2, sticky="e")
+        tk.Spinbox(frame, from_=1, to=1000, textvariable=self.bet, width=5).grid(row=1, column=3)
+
+        tk.Label(frame, text="Decks").grid(row=2, column=0, sticky="e")
+        tk.Spinbox(frame, from_=1, to=12, textvariable=self.decks, width=5).grid(row=2, column=1)
+        tk.Label(frame, text="Penetration").grid(row=2, column=2, sticky="e")
+        tk.Spinbox(frame, from_=0.25, to=0.95, increment=0.01, textvariable=self.penetration, width=5).grid(row=2, column=3)
+
+        tk.Label(frame, text="Payout").grid(row=3, column=0, sticky="e")
+        ttk.Combobox(frame, textvariable=self.payout, values=["3:2", "6:5"], state="readonly").grid(row=3, column=1)
+        tk.Label(frame, text="Dealer").grid(row=3, column=2, sticky="e")
+        ttk.Combobox(frame, textvariable=self.dealer, values=["H17", "S17"], state="readonly").grid(row=3, column=3)
+
+        tk.Checkbutton(frame, text="DAS", variable=self.das).grid(row=4, column=0)
+        tk.Checkbutton(frame, text="RSA", variable=self.rsa).grid(row=4, column=1)
+        tk.Checkbutton(frame, text="Surrender", variable=self.surrender).grid(row=4, column=2)
+
+        tk.Label(frame, text="Strategy").grid(row=5, column=0, sticky="e")
+        ttk.Entry(frame, textvariable=self.strategy_file).grid(row=5, column=1, columnspan=3, sticky="we")
+        tk.Label(frame, text="Database").grid(row=6, column=0, sticky="e")
+        ttk.Entry(frame, textvariable=self.database).grid(row=6, column=1, columnspan=3, sticky="we")
+
+        tk.Label(frame, text="Seed").grid(row=7, column=0, sticky="e")
+        ttk.Entry(frame, textvariable=self.seed).grid(row=7, column=1, columnspan=3, sticky="we")
+
+        tk.Button(frame, text="Close", command=self.settings_win.destroy).grid(row=8, column=0, columnspan=4, pady=(10, 0))
 
     def run_simulation(self):
         if self.sim:
@@ -102,6 +115,7 @@ class SimulatorGUI:
             blackjack_payout=1.5 if self.payout.get() == "3:2" else 1.2,
             double_after_split=self.das.get(),
             resplit_aces=self.rsa.get(),
+            allow_surrender=self.surrender.get(),
             bet_amount=float(self.bet.get()),
             num_decks=self.decks.get(),
             hit_soft_17=self.dealer.get() == "H17",

--- a/blackjack/player.py
+++ b/blackjack/player.py
@@ -11,6 +11,7 @@ class PlayerSettings:
     blackjack_payout: float = 1.5
     double_after_split: bool = True
     resplit_aces: bool = False
+    allow_surrender: bool = True
     bet_amount: float = 1.0  # base wager per hand
 
 @dataclass
@@ -33,7 +34,7 @@ class Player:
         action = self.strategy.decide(hand, dealer_up, {
             "can_double": can_double and not hand.is_split_aces,
             "can_split": hand.can_split,
-            "can_surrender": not hand.is_split,
+            "can_surrender": self.settings.allow_surrender and not hand.is_split,
         })
         if action == "surrender":
             hand.surrendered = True

--- a/blackjack/settings.py
+++ b/blackjack/settings.py
@@ -12,6 +12,7 @@ class SimulationSettings:
     blackjack_payout: float = 1.5
     double_after_split: bool = True
     resplit_aces: bool = False
+    allow_surrender: bool = True
     bet_amount: float = 1.0
     num_decks: int = 6
     hit_soft_17: bool = False

--- a/blackjack/simulator.py
+++ b/blackjack/simulator.py
@@ -49,7 +49,7 @@ class Simulator:
     def run(self) -> None:
         if self.settings.seed is not None:
             random.seed(self.settings.seed)
-        strat = BasicStrategy.from_json(self.settings.strategy_file)
+        strat = BasicStrategy.from_json(self.settings.strategy_file, allow_surrender=self.settings.allow_surrender)
         for trial in range(1, self.settings.trials + 1):
             shoe = Shoe(self.settings.num_decks, penetration=self.settings.penetration)
             player_settings = PlayerSettings(
@@ -57,6 +57,7 @@ class Simulator:
                 blackjack_payout=self.settings.blackjack_payout,
                 double_after_split=self.settings.double_after_split,
                 resplit_aces=self.settings.resplit_aces,
+                allow_surrender=self.settings.allow_surrender,
                 bet_amount=self.settings.bet_amount,
             )
             player = Player(player_settings, strat)

--- a/blackjack/strategy.py
+++ b/blackjack/strategy.py
@@ -23,17 +23,25 @@ class BasicStrategy:
     pair: Dict[str, Dict[str, Action]] = field(default_factory=dict)
 
     @classmethod
-    def from_json(cls, path: str) -> "BasicStrategy":  # pragma: no cover - CLI helper
+    def from_json(cls, path: str, allow_surrender: bool = True) -> "BasicStrategy":  # pragma: no cover - CLI helper
         """Create a strategy instance from ``path``.
 
         Missing sections in the JSON default to empty dictionaries which
         effectively cause the strategy to stand on every hand.
+        ``allow_surrender`` replaces any "surrender" recommendations with
+        "hit" when set to ``False``.
         """
         with open(path, "r", encoding="utf8") as f:
             data = json.load(f)
         hard = {int(k): v for k, v in data.get("hard", {}).items()}
         soft = {int(k): v for k, v in data.get("soft", {}).items()}
         pair = data.get("pair") or data.get("split") or {}
+        if not allow_surrender:
+            for table in (hard, soft, pair):
+                for row in table.values():
+                    for dealer, action in list(row.items()):
+                        if action == "surrender":
+                            row[dealer] = "hit"
         return cls(hard=hard, soft=soft, pair=pair)
 
     def _lookup(self, table: Dict, key, dealer_up: str) -> Action | None:

--- a/tests/test_payout.py
+++ b/tests/test_payout.py
@@ -1,0 +1,21 @@
+from blackjack.simulator import Simulator
+from blackjack.settings import SimulationSettings
+from blackjack.player import PlayerSettings
+from blackjack.hand import Hand
+from blackjack.cards import Card
+
+
+def test_blackjack_payout_ratios():
+    sim = Simulator(SimulationSettings(database=':memory:', blackjack_payout=1.5))
+    ps = PlayerSettings(bankroll=0, blackjack_payout=1.5)
+    hand = Hand(cards=[Card('A', 'spades'), Card('K', 'hearts')], bet=10)
+    dealer_hand = Hand(cards=[Card('9', 'clubs'), Card('7', 'diamonds')])
+    assert sim.resolve_hand(hand, dealer_hand, ps) == 10 * 2.5
+    sim.close()
+
+    sim6 = Simulator(SimulationSettings(database=':memory:', blackjack_payout=1.2))
+    ps6 = PlayerSettings(bankroll=0, blackjack_payout=1.2)
+    hand6 = Hand(cards=[Card('A', 'spades'), Card('K', 'hearts')], bet=10)
+    dealer_hand6 = Hand(cards=[Card('9', 'clubs'), Card('7', 'diamonds')])
+    assert sim6.resolve_hand(hand6, dealer_hand6, ps6) == 10 * 2.2
+    sim6.close()

--- a/tests/test_surrender.py
+++ b/tests/test_surrender.py
@@ -44,3 +44,29 @@ def test_surrender_payout_returns_half_bet():
     payout = resolve(hand, dealer_hand)
     settings.bankroll += payout
     assert settings.bankroll == 95
+
+
+class CountingShoe:
+    def __init__(self):
+        self.count = 0
+
+    def draw(self):
+        self.count += 1
+        return Card('2', 'hearts')
+
+
+class OptionAwareStrategy:
+    def decide(self, hand, dealer_up, options):
+        return 'surrender' if options.get('can_surrender') else 'hit'
+
+
+def test_no_surrender_hits_when_disabled():
+    settings = PlayerSettings(bankroll=100, allow_surrender=False)
+    bet = 10
+    settings.bankroll -= bet
+    initial = Hand(cards=[Card('9', 'spades'), Card('7', 'hearts')], bet=bet)
+    shoe = CountingShoe()
+    player = Player(settings=settings, strategy=OptionAwareStrategy())
+    hands = player.play(shoe, dealer_up='9', initial=initial)
+    hand = hands[0]
+    assert not hand.surrendered


### PR DESCRIPTION
## Summary
- Move simulation parameters into a separate settings window
- Allow enabling or disabling surrender with corresponding strategy updates
- Include tests for blackjack payout ratios and surrender-disabled play

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6aa38b3d48331a27b6ed649084958