### PR TITLE
Add test mode for dry-run simulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A modular blackjack simulation engine for exploring different strategies and cas
 - **Strategy plug-ins**: point to any JSON basic strategy file; each defines `hard`, `soft`, and `pair` tables mapping player totals and dealer up-cards to actions.
 
 - **Data output**: bankroll history, final summaries, and card distributions stored in SQLite for downstream analysis (e.g., with the included R script).
+- **Test mode**: run simulations without saving results to permanent tables to perform dry runs.
 
 - **GUI**: a Tkinter interface lets you configure rules, run simulations, visualize bankroll progression for any trial via a "Plot Trial" selector, and optionally save or discard results stored in SQLite.
 
@@ -43,6 +44,13 @@ opens like any other native app.
 pip install .
 blackjack-sim  # runs without a console window
 
+```
+
+For a dry run that leaves results only in the temporary tables, pass
+`--test-mode` to the CLI:
+
+```bash
+python -m blackjack --test-mode
 ```
 
 ### Visualization

--- a/blackjack/__main__.py
+++ b/blackjack/__main__.py
@@ -6,7 +6,7 @@ from .settings import SimulationSettings, DEFAULT_STRATEGY_FILE
 from .simulator import Simulator
 
 
-def parse_args() -> tuple[SimulationSettings, bool]:
+def parse_args() -> SimulationSettings:
     parser = argparse.ArgumentParser(description="Blackjack simulator")
     parser.add_argument("--trials", type=int, default=100)
     parser.add_argument("--hands", type=int, default=100)
@@ -21,7 +21,7 @@ def parse_args() -> tuple[SimulationSettings, bool]:
     parser.add_argument("--strategy", type=str, default=str(DEFAULT_STRATEGY_FILE))
     parser.add_argument("--database", type=str, default="simulation.db")
     parser.add_argument("--seed", type=int, default=None, help="Random seed")
-    parser.add_argument("--no-save", action="store_true", help="Do not save simulation results")
+    parser.add_argument("--test-mode", action="store_true", help="Run without persisting results")
     args = parser.parse_args()
     if not Path(args.strategy).is_file():
         parser.error(f"Strategy file '{args.strategy}' not found.")
@@ -39,8 +39,9 @@ def parse_args() -> tuple[SimulationSettings, bool]:
         strategy_file=args.strategy,
         database=args.database,
         seed=args.seed,
+        test_mode=args.test_mode,
     )
-    return settings, args.no_save
+    return settings
 
 
 def run_gui():
@@ -49,11 +50,13 @@ def run_gui():
 
 
 def run_cli():
-    settings, no_save = parse_args()
+    settings = parse_args()
     sim = Simulator(settings)
     sim.run()
-    if not no_save:
+    if not settings.test_mode:
         sim.save_results()
+    else:
+        print("Test mode enabled: results kept in temporary tables only.")
     sim.close()
 
 

--- a/blackjack/settings.py
+++ b/blackjack/settings.py
@@ -20,3 +20,4 @@ class SimulationSettings:
     strategy_file: str = str(DEFAULT_STRATEGY_FILE)
     database: str = "simulation.db"
     seed: int | None = None
+    test_mode: bool = False

--- a/blackjack/simulator.py
+++ b/blackjack/simulator.py
@@ -220,6 +220,8 @@ class Simulator:
 
     def save_results(self) -> None:
         """Persist temporary tables into permanent storage."""
+        if self.settings.test_mode:
+            raise RuntimeError("Cannot save results while in test mode")
         cur = self.conn.cursor()
         for permanent, temp in TABLE_PAIRS:
             cur.execute(f"INSERT INTO {permanent} SELECT * FROM {temp}")


### PR DESCRIPTION
## Summary
- Allow running simulations in a test mode that keeps data in temporary tables only
- Add `--test-mode` CLI flag and configuration toggle
- Prevent saving when test mode is active and document usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b73756c3888331a6563450c3fb15c7